### PR TITLE
Python3 compatibility (and general housekeeping)

### DIFF
--- a/events/actions.py
+++ b/events/actions.py
@@ -6,12 +6,10 @@ Base classes for possible actions taken on events.
 
 from __future__ import unicode_literals
 
-from django.conf import settings
+from events.conf import EVENTS_STORE_OBJECT
 from events.utils import import_object
 
-store_object_path = settings.get('EVENTS_STORE_OBJECT',
-                                 "django.core.cache.cache")
-_mod_name, _obj_name = store_object_path.rsplit('.', 1)
+_mod_name, _obj_name = EVENTS_STORE_OBJECT.rsplit('.', 1)
 _obj = import_object(_mod_name, _obj_name)
 if callable(_obj):
     _store = _obj()

--- a/events/actions.py
+++ b/events/actions.py
@@ -4,11 +4,14 @@
 Base classes for possible actions taken on events.
 """
 
-from events.conf import settings
+from __future__ import unicode_literals
+
+from django.conf import settings
 from events.utils import import_object
 
-
-_mod_name, _obj_name = settings.EVENTS_STORE_OBJECT.rsplit('.', 1)
+store_object_path = settings.get('EVENTS_STORE_OBJECT',
+                                 "django.core.cache.cache")
+_mod_name, _obj_name = store_object_path.rsplit('.', 1)
 _obj = import_object(_mod_name, _obj_name)
 if callable(_obj):
     _store = _obj()

--- a/events/conf.py
+++ b/events/conf.py
@@ -1,8 +1,0 @@
-# -*- coding: utf-8 -*-
-
-from django.conf import settings                            # NOQA
-from appconf import AppConf
-
-
-class EventsConf(AppConf):
-    STORE_OBJECT = "django.core.cache.cache"

--- a/events/conf.py
+++ b/events/conf.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+
+"""
+Configuration variables; gets them from django settings, falls back to a
+default
+"""
+
+from __future__ import unicode_literals
+
+from django.conf import settings
+
+DEFAULT_STORE_OBJECT = "django.core.cache.cache"
+EVENTS_STORE_OBJECT = getattr(settings, 'EVENTS_STORE_OBJECT',
+                              DEFAULT_STORE_OBJECT)

--- a/events/event.py
+++ b/events/event.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
 import logging
 
 

--- a/events/models.py
+++ b/events/models.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
 from django.conf import settings
 from events.event import Event
 from events.utils import import_object
@@ -6,8 +10,7 @@ from events.utils import import_object
 def _setup_events(conf):
     """Setup the events defined in the settings."""
     events = {}
-    event_names = conf.keys()
-    for name in event_names:
+    for name in conf.keys():
         events[name] = Event(name=name)
         for listener in conf[name]:
             action = 'run'

--- a/events/utils.py
+++ b/events/utils.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
 import importlib
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
 from setuptools import setup
 
 setup(
     name="django-events",
-    version="0.1b",
+    version="0.2",
     description="Events in django applications.",
     author="Apostolis Bessas",
     author_email="mpessas@transifex.com",
     packages=["events"],
-    install_requires=["Django", "django-appconf>=0.5"],
+    install_requires=["Django"],
 )


### PR DESCRIPTION
- Add `from __future__ import unicode_literals` to all files
- Run `2to3` and act on suggested change
- Run `isort`
- Removed conf.py, rely on django settings instead
- Updated version